### PR TITLE
Add the setup for chatops-based automated testing.

### DIFF
--- a/.github/workflows/slash-command-dispatch.yml
+++ b/.github/workflows/slash-command-dispatch.yml
@@ -1,0 +1,15 @@
+name: Slash Command Dispatch
+on:
+  issue_comment:
+    types: [created]
+jobs:
+  slashCommandDispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Slash Command Dispatch
+        uses: peter-evans/slash-command-dispatch@v2
+        with:
+          token: ${{ secrets.PAT }}
+          commands: test
+          permission: write
+          issue-type: pull-request

--- a/.github/workflows/test-command.yml
+++ b/.github/workflows/test-command.yml
@@ -1,0 +1,204 @@
+# Attribution for a bunch of this goes to CloudPosse
+# https://github.com/cloudposse/actions/blob/master/.github/workflows/test-command.yml
+
+name: test
+on:
+  repository_dispatch:
+    types: [test-command]
+  push:
+    branches:
+      - main
+
+permissions:
+  id-token: write
+  contents: read
+
+defaults:
+  run:
+    # We need -e -o pipefail for consistency with GitHub Actions' default behavior
+    shell: bash -e -o pipefail {0}
+
+jobs:
+  # Parse the command so we can decide which tests to run. Examples: "/test all", "/test validate", "/test e2e"
+  # We can do as many of these as we want to get as granular as we want.
+  parse:
+    runs-on: ubuntu-latest
+    outputs:
+      run-ping: ${{ steps.parse.outputs.ping }}
+      run-build: ${{ steps.parse.outputs.build }}
+      run-e2e: ${{ steps.parse.outputs.e2e }}
+    steps:
+      - name: Parse Args
+        id: parse
+        env:
+          DEBUG: ${{ toJSON(github.event.client_payload.slash_command) }}
+          ARGS_V1: ${{ github.event.client_payload.slash_command.arg1 }}
+          ARGS_V2: ${{ github.event.client_payload.slash_command.args.unnamed.all }}
+          EVENT_NAME: ${{ github.event_name }}
+        shell: bash
+        run: |
+          ARGS="${ARGS_V1}${ARGS_V2}"
+          # set ARGS to "all" if EVENT_NAME is "push"
+          if [[ "${EVENT_NAME}" == "push" ]]; then
+              ARGS="all"
+          fi
+          printf "Event name is %s\n" "$EVENT_NAME"
+          printf "Args are %s\n" "$ARGS"
+          printf "\n\nslash_command is %s\n\n" "$DEBUG"
+          COMMANDS=(PING E2E)
+          if printf "%s" "${ARGS^^}" | grep -qE '\bALL\b'; then
+            # "all" explicitly does not include "ping"
+            for cmd in "${COMMANDS[@]}"; do
+              [[ $cmd == "PING" ]] && ! { printf "%s" "${ARGS^^}" | grep -qE '\bPING\b'; } && continue
+              printf -v "$cmd" "true"
+            done
+          else
+            for cmd in "${COMMANDS[@]}"; do
+              if printf "%s" "${ARGS^^}" | grep -qE "\b${cmd}\b"; then
+                printf -v "$cmd" "true"
+              fi
+            done
+          fi
+          for out in "${COMMANDS[@]}"; do
+            printf "::set-output name=%s::%s\n" "${out,,}" "${!out:-false}"
+            printf "%s=%s\n" "${out,,}" "${!out:-false}"
+          done
+
+  # Do a simple ping/pong status update to validate things are working
+  ping:
+    runs-on: ubuntu-latest
+    needs: parse
+    if: needs.parse.outputs.run-ping == 'true'
+    steps:
+      # Update GitHub status for dispatch events
+      - name: "Update GitHub Status for this ref"
+        uses: "docker://cloudposse/github-status-updater"
+        with:
+          args: "-action update_state -state success -ref ${{ github.event.client_payload.pull_request.head.sha }} -repo ${{ github.event.client_payload.github.payload.repository.name }}"
+        env:
+          GITHUB_TOKEN: ${{ secrets.PAT }}
+          GITHUB_CONTEXT: "test / ping (${{ github.event_name }})"
+          GITHUB_DESCRIPTION: "pong"
+          GITHUB_TARGET_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          GITHUB_REF: ${{ github.event.client_payload.pull_request.head.ref }}
+          GITHUB_OWNER: ${{ github.event.client_payload.github.payload.repository.owner.login }}
+
+  # Run the E2E tests
+  e2e:
+    runs-on: ubuntu-latest
+    needs: parse
+    if: needs.parse.outputs.run-e2e == 'true'
+    steps:
+      # Update GitHub status for pending pipeline run
+      - name: "Update GitHub Status for pending"
+        if: github.event_name == 'repository_dispatch'
+        uses: docker://cloudposse/github-status-updater
+        with:
+          args: "-action update_state -state pending -ref ${{ env.REPO_SHA }} -repo ${{ env.REPO_NAME }}"
+        env:
+          REPO_SHA: ${{ github.event.client_payload.pull_request.head.sha || github.sha }}
+          REPO_NAME: ${{ github.event.client_payload.github.payload.repository.name || github.event.repository.name }}
+          GITHUB_TOKEN: ${{ secrets.PAT }}
+          GITHUB_CONTEXT: "test / e2e (${{ github.event_name }})"
+          GITHUB_DESCRIPTION: "started by @${{ github.event.client_payload.github.actor || github.actor }}"
+          GITHUB_TARGET_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          GITHUB_REF: ${{ github.event.client_payload.pull_request.head.ref || github.ref_name }}
+          GITHUB_OWNER: ${{ github.event.client_payload.github.payload.repository.owner.login || github.repository_owner }}
+
+      # Checkout the code from GitHub Pull Request
+      - name: "Checkout the code"
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.PAT }}
+          repository: ${{ github.event.client_payload.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event.client_payload.pull_request.head.ref || github.ref_name }}
+
+      - name: Init gopath cache
+        uses: actions/cache@v3
+        with:
+          path: "${{ github.workspace }}/.cache/go"
+          key: "gopath|${{ hashFiles('.tool-versions') }}|${{ hashFiles('go.sum') }}"
+
+      - name: Init gobuild cache
+        uses: actions/cache@v3
+        with:
+          path: "${{ github.workspace }}/.cache/go-build"
+          key: "gobuild|${{ hashFiles('.tool-versions') }}|${{ hashFiles('go.sum') }}"
+
+      - name: Init docker cache
+        id: init-docker-cache
+        uses: actions/cache@v3
+        with:
+          path: "${{ github.workspace }}/.cache/docker"
+          key: "docker|${{ hashFiles('Makefile') }}"
+
+      - name: Docker save build harness
+        if: steps.init-docker-cache.outputs.cache-hit != 'true'
+        run: |
+          make docker-save-build-harness
+
+      - name: Load build harness
+        run: |
+          make docker-load-build-harness
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          role-session-name: ${{ github.event.client_payload.pull_request.head.sha || github.sha }}
+          aws-region: us-east-1
+
+      - name: "Run E2E tests"
+        env:
+          REPO_URL: https://github.com/${{ github.repository }}.git
+          GIT_BRANCH: ${{ github.event.client_payload.pull_request.head.ref || github.ref_name }}
+        run: |
+          make test fix-cache-permissions
+
+      # Update GitHub status for failing pipeline run
+      - name: "Update GitHub Status for failure"
+        if: ${{ failure() && github.event_name == 'repository_dispatch' }}
+        uses: docker://cloudposse/github-status-updater
+        with:
+          args: "-action update_state -state failure -ref ${{ env.REPO_SHA }} -repo ${{ env.REPO_NAME }}"
+        env:
+          REPO_SHA: ${{ github.event.client_payload.pull_request.head.sha || github.sha }}
+          REPO_NAME: ${{ github.event.client_payload.github.payload.repository.name || github.event.repository.name }}
+          GITHUB_TOKEN: ${{ secrets.PAT }}
+          GITHUB_CONTEXT: "test / e2e (${{ github.event_name }})"
+          GITHUB_DESCRIPTION: "run failed"
+          GITHUB_TARGET_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          GITHUB_REF: ${{ github.event.client_payload.pull_request.head.ref || github.ref_name }}
+          GITHUB_OWNER: ${{ github.event.client_payload.github.payload.repository.owner.login || github.repository_owner }}
+
+      # Update GitHub status for successful pipeline run
+      - name: "Update GitHub Status for success"
+        if: github.event_name == 'repository_dispatch'
+        uses: docker://cloudposse/github-status-updater
+        with:
+          args: "-action update_state -state success -ref ${{ env.REPO_SHA }} -repo ${{ env.REPO_NAME }}"
+        env:
+          REPO_SHA: ${{ github.event.client_payload.pull_request.head.sha || github.sha }}
+          REPO_NAME: ${{ github.event.client_payload.github.payload.repository.name || github.event.repository.name }}
+          GITHUB_TOKEN: ${{ secrets.PAT }}
+          GITHUB_CONTEXT: "test / e2e (${{ github.event_name }})"
+          GITHUB_DESCRIPTION: "run passed"
+          GITHUB_TARGET_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          GITHUB_REF: ${{ github.event.client_payload.pull_request.head.ref || github.ref_name }}
+          GITHUB_OWNER: ${{ github.event.client_payload.github.payload.repository.owner.login || github.repository_owner }}
+
+      # Update GitHub status for cancelled pipeline run
+      - name: "Update GitHub Status for cancelled"
+        if: ${{ cancelled() && github.event_name == 'repository_dispatch' }}
+        uses: docker://cloudposse/github-status-updater
+        with:
+          args: "-action update_state -state error -ref ${{ env.REPO_SHA }} -repo ${{ env.REPO_NAME }}"
+        env:
+          REPO_SHA: ${{ github.event.client_payload.pull_request.head.sha || github.sha }}
+          REPO_NAME: ${{ github.event.client_payload.github.payload.repository.name || github.event.repository.name }}
+          GITHUB_TOKEN: ${{ secrets.PAT }}
+          GITHUB_CONTEXT: "test / e2e (${{ github.event_name }})"
+          GITHUB_DESCRIPTION: "run cancelled"
+          GITHUB_TARGET_URL: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          GITHUB_REF: ${{ github.event.client_payload.pull_request.head.ref || github.ref_name }}
+          GITHUB_OWNER: ${{ github.event.client_payload.github.payload.repository.owner.login || github.repository_owner }}


### PR DESCRIPTION
Note: This won't actually work until `secrets.AWS_ROLE_TO_ASSUME` exists. We'll need to figure out which AWS account these tests run in first.