### PR TITLE
State backend creation and management

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,7 @@ override.tf.json
 # example: *tfplan*
 
 examples/complete/.terraform.lock.hcl
+
+terraform.tfvars
+backend.tf*
+.terraform.lock.hcl

--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ Ensure Terraform is available on the local system and that the AWS CLI has the a
 To view examples for how you can leverage this tfstate-backend Module, please see the [examples](./examples) directory.
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
-<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 No requirements.
@@ -23,8 +22,8 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.65.0 |
-| <a name="provider_local"></a> [local](#provider\_local) | 2.4.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+| <a name="provider_local"></a> [local](#provider\_local) | n/a |
 
 ## Modules
 
@@ -64,5 +63,4 @@ No requirements.
 |------|-------------|
 | <a name="output_tfstate_bucket_id"></a> [tfstate\_bucket\_id](#output\_tfstate\_bucket\_id) | Terraform State Bucket Name |
 | <a name="output_tfstate_dynamodb_table_name"></a> [tfstate\_dynamodb\_table\_name](#output\_tfstate\_dynamodb\_table\_name) | Terraform State DynamoDB Table Name |
-<!-- END_TF_DOCS -->
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Ensure Terraform is available on the local system and that the AWS CLI has the a
 To view examples for how you can leverage this tfstate-backend Module, please see the [examples](./examples) directory.
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 No requirements.
@@ -22,7 +23,8 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.65.0 |
+| <a name="provider_local"></a> [local](#provider\_local) | 2.4.0 |
 
 ## Modules
 
@@ -40,6 +42,7 @@ No requirements.
 | [aws_s3_bucket_logging.logging](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_logging) | resource |
 | [aws_s3_bucket_policy.backend_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
 | [aws_s3_bucket_versioning.versioning](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning) | resource |
+| [local_file.terraform_backend_config](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
 | [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
 
 ## Inputs
@@ -61,4 +64,5 @@ No requirements.
 |------|-------------|
 | <a name="output_tfstate_bucket_id"></a> [tfstate\_bucket\_id](#output\_tfstate\_bucket\_id) | Terraform State Bucket Name |
 | <a name="output_tfstate_dynamodb_table_name"></a> [tfstate\_dynamodb\_table\_name](#output\_tfstate\_dynamodb\_table\_name) | Terraform State DynamoDB Table Name |
+<!-- END_TF_DOCS -->
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -18,7 +18,7 @@ This is how to provision the S3 bucket and DynamoDB table, then push the local s
 1. Validate if you need, but there will now be a new copy of the backend called `backend.tf`. Do not lose this file. The bucket and table should be reused for future deployments.
 
 **Destroying resoruces**
-Destroying the environment with Terraform requires a few more steps than ususal. This is due to the state file being in the remote bucket. 
+Destroying the environment with Terraform requires a few more steps than ususal. This is due to the state file being in the remote bucket.
 
 1. Copy the state file locally with `terraform state pull > terraform.state`
 1. Move the backend out of scope `mv backend.tf backend.tf.bk`
@@ -68,3 +68,45 @@ No requirements.
 | <a name="output_tfstate_bucket_id"></a> [tfstate\_bucket\_id](#output\_tfstate\_bucket\_id) | Terraform State Bucket Name |
 | <a name="output_tfstate_dynamodb_table_name"></a> [tfstate\_dynamodb\_table\_name](#output\_tfstate\_dynamodb\_table\_name) | Terraform State DynamoDB Table Name |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+No requirements.
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.56.0 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_tfstate_backend"></a> [tfstate\_backend](#module\_tfstate\_backend) | ../.. | n/a |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_admin_arns"></a> [admin\_arns](#input\_admin\_arns) | ARNs of IAM users or roles that can administer the bucket. An empty list will allow all principals to administer the bucket. | `list(string)` | `[]` | no |
+| <a name="input_bucket_prefix"></a> [bucket\_prefix](#input\_bucket\_prefix) | S3 Bucket Prefix | `string` | n/a | yes |
+| <a name="input_dynamodb_table_name"></a> [dynamodb\_table\_name](#input\_dynamodb\_table\_name) | DynamoDB Table Name | `string` | n/a | yes |
+| <a name="input_permissions_boundary"></a> [permissions\_boundary](#input\_permissions\_boundary) | (Optional) The ARN of the policy that is used to set the permissions boundary for the role. | `string` | `""` | no |
+| <a name="input_region"></a> [region](#input\_region) | AWS Region | `string` | n/a | yes |
+| <a name="input_versioning_enabled"></a> [versioning\_enabled](#input\_versioning\_enabled) | Enable versioning on the S3 bucket | `bool` | `true` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_tfstate_bucket_id"></a> [tfstate\_bucket\_id](#output\_tfstate\_bucket\_id) | Terraform State Bucket Name |
+| <a name="output_tfstate_dynamodb_table_name"></a> [tfstate\_dynamodb\_table\_name](#output\_tfstate\_dynamodb\_table\_name) | Terraform State DynamoDB Table Name |
+<!-- END_TF_DOCS -->

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -36,48 +36,6 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
-
-## Modules
-
-| Name | Source | Version |
-|------|--------|---------|
-| <a name="module_tfstate_backend"></a> [tfstate\_backend](#module\_tfstate\_backend) | ../.. | n/a |
-
-## Resources
-
-| Name | Type |
-|------|------|
-| [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |
-
-## Inputs
-
-| Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
-| <a name="input_admin_arns"></a> [admin\_arns](#input\_admin\_arns) | ARNs of IAM users or roles that can administer the bucket. An empty list will allow all principals to administer the bucket. | `list(string)` | `[]` | no |
-| <a name="input_bucket_prefix"></a> [bucket\_prefix](#input\_bucket\_prefix) | S3 Bucket Prefix | `string` | n/a | yes |
-| <a name="input_dynamodb_table_name"></a> [dynamodb\_table\_name](#input\_dynamodb\_table\_name) | DynamoDB Table Name | `string` | n/a | yes |
-| <a name="input_permissions_boundary"></a> [permissions\_boundary](#input\_permissions\_boundary) | (Optional) The ARN of the policy that is used to set the permissions boundary for the role. | `string` | `""` | no |
-| <a name="input_region"></a> [region](#input\_region) | AWS Region | `string` | n/a | yes |
-| <a name="input_versioning_enabled"></a> [versioning\_enabled](#input\_versioning\_enabled) | Enable versioning on the S3 bucket | `bool` | `true` | no |
-
-## Outputs
-
-| Name | Description |
-|------|-------------|
-| <a name="output_tfstate_bucket_id"></a> [tfstate\_bucket\_id](#output\_tfstate\_bucket\_id) | Terraform State Bucket Name |
-| <a name="output_tfstate_dynamodb_table_name"></a> [tfstate\_dynamodb\_table\_name](#output\_tfstate\_dynamodb\_table\_name) | Terraform State DynamoDB Table Name |
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
-
-<!-- BEGIN_TF_DOCS -->
-## Requirements
-
-No requirements.
-
-## Providers
-
-| Name | Version |
-|------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | 4.56.0 |
 
 ## Modules
@@ -109,4 +67,4 @@ No requirements.
 |------|-------------|
 | <a name="output_tfstate_bucket_id"></a> [tfstate\_bucket\_id](#output\_tfstate\_bucket\_id) | Terraform State Bucket Name |
 | <a name="output_tfstate_dynamodb_table_name"></a> [tfstate\_dynamodb\_table\_name](#output\_tfstate\_dynamodb\_table\_name) | Terraform State DynamoDB Table Name |
-<!-- END_TF_DOCS -->
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -36,7 +36,7 @@ No requirements.
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.56.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
 
 ## Modules
 

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -4,7 +4,9 @@ This example should create an S3 bucket bucket and DynamoDB table.
 
 ## Example Steps
 
-Standard Terraform Workflow
+**Standard Terraform Workflow**
+This is how to provision the S3 bucket and DynamoDB table, then push the local state file to the bucket and use matched lock file.
+
 1. Checkout this code.
 1. Change Directory to this folder.
 1. Ensure AWS CLI is configured (AWS Profile, temporary assume role, or setting environment variable).
@@ -12,7 +14,18 @@ Standard Terraform Workflow
 1. Run `terraform init`.
 1. Verify with `terraform plan`
 1. Deploy with `terraform apply`
-1. Delete with `terraform destroy`
+1. Push local state file to bucket with `terraform init -force copy`
+1. Validate if you need, but there will now be a new copy of the backend called `backend.tf`. Do not lose this file. The bucket and table should be reused for future deployments.
+
+**Destroying resoruces**
+Destroying the environment with Terraform requires a few more steps than ususal. This is due to the state file being in the remote bucket. 
+
+1. Copy the state file locally with `terraform state pull > terraform.state`
+1. Move the backend out of scope `mv backend.tf backend.tf.bk`
+1. Run the init again `terraform init -force-copy`
+1. Finally destroying resources with `terraform destroy -auto-approve`
+  1. The S3 bucket may not be deleted and may have to be manually emptied before deletion. Ensure the state file has been bulled prior to clearing the bucket.
+
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements

--- a/installer.sh
+++ b/installer.sh
@@ -1,24 +1,5 @@
-#!/bin/bash
-# This script assumes terraform apply has been completed already creating an S3 bucket and DynamoDB table.
+!#/bin/bash
 
-# Read from the state file to get outputs and save in variables
-
-table=$(jq '.outputs.lock_table.value' terraform.tfstate -r)
-bucket=$(jq '.outputs.tfbucket.value' terraform.tfstate -r)
-localName=${table::-6}
-thisRegion=$(jq '.resources[] | select(.name == "tfbucket")| .instances[].attributes.region' terraform.tfstate -r)
-
-# First write backend
-cat << EOL > backend.tf
-terraform {
-  backend "s3" {
-    bucket         = "${bucket}"
-    key            = "statefiles/${thisRegion}/${localName}.tfstate"
-    region         = "${thisRegion}"
-    dynamodb_table = "${table}"
-  }
-}
-EOL
-
-# Finally, rerun init so the s3 backend is set and state file is moved
-terraform init -migrate-state -force-copy
+terraform init
+terraform apply --auto-approve
+terraform init -force-copy

--- a/installer.sh
+++ b/installer.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# This script assumes terraform apply has been completed already creating an S3 bucket and DynamoDB table.
+
+# Read from the state file to get outputs and save in variables
+
+table=$(jq '.outputs.lock_table.value' terraform.tfstate -r)
+bucket=$(jq '.outputs.tfbucket.value' terraform.tfstate -r)
+localName=${table::-6}
+thisRegion=$(jq '.resources[] | select(.name == "tfbucket")| .instances[].attributes.region' terraform.tfstate -r)
+
+# First write backend
+cat << EOL > backend.tf
+terraform {
+  backend "s3" {
+    bucket         = "${bucket}"
+    key            = "statefiles/${thisRegion}/${localName}.tfstate"
+    region         = "${thisRegion}"
+    dynamodb_table = "${table}"
+  }
+}
+EOL
+
+# Finally, rerun init so the s3 backend is set and state file is moved
+terraform init -migrate-state -force-copy

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,6 @@
 locals {
   create_bucket_policy = length(var.admin_arns) > 0 ? true : false
   backend_content = {
-
     region               = var.region
     bucket               = module.s3_bucket.s3_bucket_id
     terraform_state_file = "tfstate/${var.region}/${var.bucket_prefix}-bucket.tfstate"

--- a/remover.sh
+++ b/remover.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+terraform state pull > terraform.tfstat
+rm -rf backend.tf .terraform/terraform.tfstat
+terraform init # needed after removing backend
+terraform destroy --auto-approve
+rm -rf backend.tf terraform.* .terraform

--- a/remover.sh
+++ b/remover.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 
-terraform state pull > terraform.tfstat
-rm -rf backend.tf .terraform/terraform.tfstat
-terraform init # needed after removing backend
+rm -rf .terraform* terraform.tfstate*
+terraform init
+terraform state pull > terraform.tfstate
+cp terraform.tfstate protection.terraform.tfstate
+mv backend.tf backend.tf.bk
+terraform init -force-copy # needed after removing backend
 terraform destroy --auto-approve
-rm -rf backend.tf terraform.* .terraform
+rm -rf terraform.tfstate* .terraform

--- a/templates/backend.tf.tmpl
+++ b/templates/backend.tf.tmpl
@@ -1,0 +1,10 @@
+terraform {
+  backend "s3" {
+    region         = "${region}"
+    bucket         = "${bucket}"
+    key            = "${terraform_state_file}"
+    %{~ if dynamodb_table != "" ~}
+    dynamodb_table = "${dynamodb_table}"
+    %{~ endif ~}
+  }
+}


### PR DESCRIPTION
Closes #33. 

**Changes:**
* New template to generate a `backend.tf` of the S3 bucket. 
* 2 scripts for example installation and removal (may be used for testing).
* Example has an updated readme for migrating state with Terraform commands and order.