### PR TITLE
Renovate more ASDF things

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,10 +1,17 @@
+# renovate: datasource=github-tags depName=npryce/adr-tools
 adr-tools 3.0.0
+# renovate: datasource=github-tags depName=bridgecrewio/checkov
 checkov 2.3.3
 golang 1.20.3
+# renovate: datasource=github-tags depName=golangci/golangci-lint
 golangci-lint 1.50.1
+# renovate: datasource=github-tags depName=pre-commit/pre-commit
 pre-commit 3.0.1
 terraform 1.4.6
+# renovate: datasource=github-tags depName=terraform-docs/terraform-docs
 terraform-docs 0.16.0
+# renovate: datasource=github-tags depName=terraform-linters/tflint
 tflint 0.44.1
+# renovate: datasource=github-tags depName=aquasecurity/tfsec
 tfsec 1.28.1
 make 4.4

--- a/renovate.json5
+++ b/renovate.json5
@@ -21,6 +21,15 @@
         "BUILD_HARNESS_REPO := (?<depName>\\S+)\\nBUILD_HARNESS_VERSION := (?<currentValue>\\S+)"
       ],
       "datasourceTemplate": "docker"
+    },
+    // Custom regex manager for the .tool-versions file that follows the pattern documented here: https://docs.renovatebot.com/modules/manager/regex/#advanced-capture
+    {
+      "fileMatch": ["^.tool-versions$"],
+      "matchStrings": [
+        "datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\s.*? (?<currentValue>.*)\\s"
+      ],
+      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver-coerced{{/if}}",
+      "extractVersionTemplate": "^v?(?<version>.*)$"
     }
   ]
 }


### PR DESCRIPTION
Renovate doesn't support all the different ASDF plugins that are listed in .tool-versions. This tells Renovate how to check for the ones that it doesn't support natively yet.

Copied from (and tested in) [here](https://github.com/defenseunicorns/delivery-aws-iac)