### PR TITLE
add paths-ignore

### DIFF
--- a/.github/workflows/test-module.yml
+++ b/.github/workflows/test-module.yml
@@ -11,6 +11,8 @@ on:
       - ready_for_review
     branches:
       - main
+    paths-ignore:
+      - "**.md"
 
 permissions:
   id-token: write


### PR DESCRIPTION
Don't run the automated tests if the changes are markdown-only