### PR TITLE
PROPOSAL: Update Renovate config to do all changes in one PR, rather than 1 PR per change

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,7 +1,19 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base"
+    // Tells Renovate to maintain one GitHub issue as the "dependency dashboard". See https://docs.renovatebot.com/key-concepts/dashboard
+    ":dependencyDashboard",
+    // Use semantic commit type fix for dependencies and chore for all others if semantic commits are in use. See https://docs.renovatebot.com/presets-default/#semanticprefixfixdepschoreothers
+    ":semanticPrefixFixDepsChoreOthers",
+    // Ignore node_modules, bower_components, vendor and various test/tests directories. See https://docs.renovatebot.com/presets-default/#ignoremodulesandtests
+    ":ignoreModulesAndTests",
+    // Group all updates together. See https://docs.renovatebot.com/presets-group/#groupall
+    // Other less drastic groupings that may be of interest include: group:allNonMajor, group:recommended, group:monorepos
+    "group:all",
+    // Apply crowd-sourced package replacement rules. See https://docs.renovatebot.com/presets-replacements/#replacementsall
+    "replacements:all",
+    // Apply crowd-sourced workarounds for known problems with packages. See https://docs.renovatebot.com/presets-workarounds/#workaroundsall
+    "workarounds:all"
   ],
   "labels": [
     "renovate"


### PR DESCRIPTION
This proposed change would group all Renovate changes into one PR, rather than one PR per change. I believe this would be an overall positive change by reducing cognitive burden on the team, and reducing the number of test pipelines that have to run.