### PR TITLE
Update bucket policy

### DIFF
--- a/templates/backend_bucket_bucket_policy.json.tpl
+++ b/templates/backend_bucket_bucket_policy.json.tpl
@@ -2,37 +2,38 @@
   "Version": "2012-10-17",
   "Statement": [
     {
+      "Action": [
+        "s3:ListBucket",
+        "s3:GetObject",
+        "s3:PutObject"
+      ],
       "Effect": "Allow",
+      "Resource": [
+        "${s3_bucket_arn}/*",
+        "${s3_bucket_arn}"
+      ],
+      "Condition": {
+        "Bool": {
+          "aws:SecureTransport": "false"
+        }
+      },
       "Principal": {
         "AWS": ${admin_arns}
-  },
-    "Action": [
-      "s3:ListBucket",
-      "s3:GetObject",
-      "s3:PutObject"
-    ],
-    "Resource": [
-      "${s3_bucket_arn}/*",
-      "${s3_bucket_arn}"
-    ],
-    "Condition": {
-      "Bool": {
-        "aws:SecureTransport": "false"
       }
-    }
     },
     {
-      "NotPrincipal": {
-        "AWS": ${admin_arns}
-  },
-    "Action": [
-      "s3:*"
-    ],
-    "Resource": [
-      "${s3_bucket_arn}/*",
-      "${s3_bucket_arn}"
-    ],
-    "Effect": "Deny"
+      "Action": "s3:*",
+      "Effect": "Deny",
+      "Resource": [
+        "${s3_bucket_arn}/*",
+        "${s3_bucket_arn}"
+      ],
+      "Condition": {
+        "ArnNotEquals": {
+          "aws:PrincipalArn": ${admin_arns}
+        }
+      },
+      "Principal": "*"
     }
   ]
 }


### PR DESCRIPTION
updated the S3 bucket policy DENY statement so that it works for additional users/roles.

As of right now, Admins need to manually add the IAM `bastion-role` to the tfstate backend S3 bucket policy in order to deploy DUBBD pkgs from an EC2 bastion instance that assumes the `bastion-role` IAM role.

The `NotPrincipal` condition blocks all non-admin user/roles even if they user/role is added to the `Allow` statement. 

The new DENY statement works as expected now