### PR TITLE
Update to .env pattern for Build Harness

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,3 @@
+BUILD_HARNESS_REPO=ghcr.io/defenseunicorns/build-harness/build-harness
+# renovate: datasource=github-tags depName=defenseunicorns/build-harness
+BUILD_HARNESS_VERSION=1.1.0

--- a/.env
+++ b/.env
@@ -1,3 +1,3 @@
 BUILD_HARNESS_REPO=ghcr.io/defenseunicorns/build-harness/build-harness
 # renovate: datasource=github-tags depName=defenseunicorns/build-harness
-BUILD_HARNESS_VERSION=1.1.0
+BUILD_HARNESS_VERSION=1.2.0

--- a/.github/actions/init-pipeline/action.yml
+++ b/.github/actions/init-pipeline/action.yml
@@ -22,7 +22,7 @@ runs:
       uses: actions/cache@v3
       with:
         path: "${{ github.workspace }}/.cache/docker"
-        key: "docker|${{ hashFiles('Makefile') }}"
+        key: "docker|${{ hashFiles('.env') }}"
 
     - name: Docker save build harness
       if: steps.init-docker-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/run-pre-commit.yml
+++ b/.github/workflows/run-pre-commit.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: "${{ github.workspace }}/.cache/docker"
-          key: docker|${{ hashFiles('Makefile') }}
+          key: docker|${{ hashFiles('.env') }}
 
       - name: Docker save build harness
         if: steps.init-docker-cache.outputs.cache-hit != 'true'

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,4 @@
-# The version of the build harness container to use
-BUILD_HARNESS_REPO := ghcr.io/defenseunicorns/build-harness/build-harness
-BUILD_HARNESS_VERSION := 1.1.0
+include .env
 
 .DEFAULT_GOAL := help
 

--- a/renovate.json5
+++ b/renovate.json5
@@ -22,15 +22,14 @@
     "enabled": true
   },
   "regexManagers": [
-    // Build Harness version
+    // Custom regex manager for the .env file that follows the pattern documented here: https://docs.renovatebot.com/modules/manager/regex/#advanced-capture
     {
-      "fileMatch": [
-        "^Makefile$"
-      ],
+      "fileMatch": ["^.env"],
       "matchStrings": [
-        "BUILD_HARNESS_REPO := (?<depName>\\S+)\\nBUILD_HARNESS_VERSION := (?<currentValue>\\S+)"
+        "datasource=(?<datasource>.*?) depName=(?<depName>.*?)( versioning=(?<versioning>.*?))?\\s.*?_VERSION=(?<currentValue>.*)\\s"
       ],
-      "datasourceTemplate": "docker"
+      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver-coerced{{/if}}",
+      "extractVersionTemplate": "^v?(?<version>.*)$"
     },
     // Custom regex manager for the .tool-versions file that follows the pattern documented here: https://docs.renovatebot.com/modules/manager/regex/#advanced-capture
     {


### PR DESCRIPTION
Advantages of this ".env" pattern:
- The docker cache in CI gets busted a lot less frequently since it is keying off of changes in the hash of the .env file rather than the full Makefile
- It is the same pattern used in:
    - https://github.com/defenseunicorns/delivery-aws-iac
    - https://github.com/defenseunicorns/terraform-aws-uds-bastion
    - https://github.com/defenseunicorns/terraform-aws-uds-rds
    - https://github.com/defenseunicorns/terraform-aws-uds-vpc
    - https://github.com/defenseunicorns/terraform-aws-uds-eks
    - https://github.com/defenseunicorns/terraform-aws-uds-cloudtrail

Also:
- Change the Renovate datasource for Build Harness from docker to github-tags. Docker as a datasource is very slow to pick up new versions compared to github-tags